### PR TITLE
Use https github url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/qless/qless-core"]
 	path = lib/qless/qless-core
-	url = git@github.com:seomoz/qless-core.git
+	url = https://github.com/seomoz/qless-core.git


### PR DESCRIPTION
This fixes the submodule on systems that don't have github-enabled SSH keys, so can't authenticate with SSH.
