### PR TITLE
Failing spec demonstrating a bug with recurring jobs of diff priority

### DIFF
--- a/spec/integration/qless_spec.rb
+++ b/spec/integration/qless_spec.rb
@@ -55,6 +55,31 @@ module Qless
         client.deregister_workers(queue.worker_name)
         expect(client.workers.counts).to eq({})
       end
+
+      it 'pops a high pri job before a low pri job when they recur at the same moment' do
+        Time.freeze
+
+        interval = 10
+
+        enqueue_with_priority = lambda do |priority, jid|
+          q.recur(Qless::Job, {}, interval,
+                  :jid => jid, :offset => (interval / 2),
+                  :priority => priority)
+        end
+
+        enqueue_with_priority[10,   "low_pri"]
+        enqueue_with_priority[1000, "high_pri"]
+        enqueue_with_priority[100,  "med_pri"]
+
+        Time.advance(10)
+
+        # Note: you can make this spec pass by uncommenting this line
+        # q.peek(3)
+
+        q.pop.jid.should include('high_pri')
+        q.pop.jid.should include('med_pri')
+        q.pop.jid.should include('low_pri')
+      end
     end
 
     it 'exposes tracking jobs' do


### PR DESCRIPTION
This is a bug we ran into due to the changes in https://github.com/seomoz/qless-core/commit/bea9915f7aea673b47fca37ab2f68b3b313a6b46. It's very subtle, so an example will demonstrate best:
- Recurring jobs `high_pri` and `low_pri` are enqueued with the same recurrence schedule, but different priorities.
- Previously, `queue.pop` would always pop a `high_pri` job before a `low_pri` job, as it should.
- With the change in that commit, `queue.pop` only spawns 1 job from the recurring queue to the work queue.  Given that the recurring queue is a sorted set scored by a timestamp indicating "when to spawn a job next", there's no guarantee about which of the two jobs will be the first one returned by the limited`zrangebyscore` command used in `pop`.  Thus, the `low_pri` job can be moved to the work queue first, and be popped first.

I'm not sure what the fix should be for this but I came up with a failing spec.

Let me know if you have any questions, @dlecocq.
