### PR TITLE
The worker should remove itself from the workers list on shutdown

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -141,7 +141,7 @@ module Qless
     # Lua scripts
     attr_reader :_cancel, :_config, :_complete, :_fail, :_failed, :_get, :_heartbeat, :_jobs, :_peek, :_pop
     attr_reader :_priority, :_put, :_queues, :_recur, :_retry, :_stats, :_tag, :_track, :_workers, :_depends
-    attr_reader :_pause, :_unpause, :_deregister_worker
+    attr_reader :_pause, :_unpause, :_deregister_workers
     # A real object
     attr_reader :config, :redis, :jobs, :queues, :workers
     
@@ -153,7 +153,7 @@ module Qless
       @config = Config.new(self)
       ['cancel', 'config', 'complete', 'depends', 'fail', 'failed', 'get', 'heartbeat', 'jobs', 'peek', 'pop',
         'priority', 'put', 'queues', 'recur', 'retry', 'stats', 'tag', 'track', 'workers', 'pause', 'unpause',
-        'deregister_worker'].each do |f|
+        'deregister_workers'].each do |f|
         self.instance_variable_set("@_#{f}", Lua.new(f, @redis))
       end
       

--- a/lib/qless/worker.rb
+++ b/lib/qless/worker.rb
@@ -140,7 +140,7 @@ module Qless
 
   private
     def deregister
-      @client._deregister_worker.call([],[Qless.worker_name])
+      @client._deregister_workers.call([],[Qless.worker_name])
     end
 
     def retryable_exception_classes(job)

--- a/spec/integration/qless_spec.rb
+++ b/spec/integration/qless_spec.rb
@@ -1694,18 +1694,20 @@ module Qless
           "stalled" => {}
         })
       end
-      
-      it "removes deregistered workers" do
-        jid = q.put(Qless::Job, {"test" => "workers_reput"})
-        job = q.pop
-        client.workers.counts.should eq([{
-          "name"    => q.worker_name,
-          "jobs"    => 1,
-          "stalled" => 0
-        }])
-        client._deregister_worker.call([], [q.worker_name])
-        client.workers.counts.should eq({})
+
+      def registered_worker_names
+        client.workers.counts.map { |w| w['name'] }
       end
+
+      it 'removes deregistered workers' do
+        q.put(Qless::Job, {"test" => "workers_reput"})
+        q.pop
+
+        expect {
+          client._deregister_workers.call([], [q.worker_name])
+        }.to change { registered_worker_names }.from([q.worker_name]).to([])
+      end
+
     end
     
     describe "#jobs" do


### PR DESCRIPTION
This is my proposed patch for #38.

I figured instead of setting the last_updated value to zero for the worker and rely on the max-worker-age pruning the worker can be deleted right away but I'm happy to change it if there are concerns.
