### PR TITLE
Make the server client instance rather than class state.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 group :development do
   gem 'debugger', :platform => :mri
 end
+
+gem 'thin' # needed by qless-web binary

--- a/exe/qless-web
+++ b/exe/qless-web
@@ -9,8 +9,9 @@ rescue LoadError
 end
 
 require 'qless/server'
+client = Qless::Client.new
 
-Vegas::Runner.new(Qless::Server, 'qless-web', {
+Vegas::Runner.new(Qless::Server.new(client), 'qless-web', {
   :before_run => lambda {|v|
     path = (ENV['RESQUECONFIG'] || v.args.first)
     load path.to_s.strip if path

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -20,8 +20,7 @@ module Qless
     let(:other)  { client.queues["other"]   }
 
     before(:all) do
-      Qless::Server.client = Qless::Client.new(redis_config)
-      Capybara.app = Qless::Server.new
+      Capybara.app = Qless::Server.new(Qless::Client.new(redis_config))
     end
 
     def first(selector, options = {})
@@ -748,12 +747,7 @@ module Qless
 
     # Our main test queue
     let(:q)      { client.queues["testing"] }
-    let(:app)    { Qless::Server            }
-
-    before(:all) do
-      Qless::Server.client = Qless::Client.new(redis_config)
-      Capybara.app = Qless::Server.new
-    end
+    let(:app)    { Qless::Server.new(Qless::Client.new(redis_config)) }
 
     it 'can access the JSON endpoints for queue sizes' do
       jid = q.put(Qless::Job, {})


### PR DESCRIPTION
We're going to be sharding our qless usage soon and having multiple qless redis servers.  We would like to have on web UI per qless redis server, and each needs to be connected to a different qless redis server.

Note that this may break some folks who use Qless: this removes support for setting the qless client directly on the `Qless::Server` class.  However, that was a hack.  I could add some kind of backwards compatibility thing but would prefer just to remove it altogether.

/cc @proby @dlecocq 
