### PR TITLE
empty arrays in job data are not properly (de)serialized

### DIFF
--- a/spec/integration/qless_spec.rb
+++ b/spec/integration/qless_spec.rb
@@ -550,6 +550,12 @@ module Qless
         job.history[0]['q'].should eq("testing")
       end
       
+      it "supports empty arrays in job data" do
+        jid = q.put(Qless::Job, {"test"=>[]})
+        job = client.jobs[jid]
+        job.data.should            eq({"test"=>[]})
+      end
+
       it "can put, peek, and pop many" do
         # In this test, we're going to add several jobs, and make
         # sure that they:


### PR DESCRIPTION
I just run across a glitch with qless that empty arrays in job data are not properly serialized and  deserialized in qless. They wind up as empty hashes when fetching the jobs data from redis.

Thats because lua knows only tables and has no way of distinguishing between an empty object and an empty array:

```
redis> EVAL 'return cjson.encode(cjson.decode(\'[]\'))' 0
"{}"
```

Definitely not a big issue but I don't really like the limitation caused by the in principle unnecessary decoding and encoding of the job data via `cjson` as qless does nothing with the job specific data.

I tried to fix this by saving the raw unprocessed JSON to redis in the `put.lua` script which is straight forward. Then I noticed that its a little more difficult to have the `get.lua` script also pass back the unprocessed JSON as the script's result is wrapped in a big `cjson.encode(...)`.

Attached is a simple failing spec for the issue.

What do you think? Is this worth tackling or do we need to live with it as a limitation of the lua interpreter?
