### PR TITLE
Remove worker client reference.

### DIFF
--- a/lib/qless/job.rb
+++ b/lib/qless/job.rb
@@ -104,6 +104,10 @@ module Qless
       @expires_at - Time.now.to_f
     end
 
+    def reconnect_to_redis
+      @client.redis.client.reconnect
+    end
+
     # Move this from it's current queue into another
     def move(queue)
       note_state_change do

--- a/lib/qless/worker.rb
+++ b/lib/qless/worker.rb
@@ -7,8 +7,8 @@ module Qless
   # This is heavily inspired by Resque's excellent worker:
   # https://github.com/defunkt/resque/blob/v1.20.0/lib/resque/worker.rb
   class Worker
-    def initialize(client, job_reserver, options = {})
-      @client, @job_reserver = client, job_reserver
+    def initialize(job_reserver, options = {})
+      @job_reserver = job_reserver
       @shutdown = @paused = false
 
       self.very_verbose = options[:very_verbose]
@@ -59,7 +59,7 @@ module Qless
       options[:very_verbose] = !!ENV['VVERBOSE']
       options[:run_as_single_process] = !!ENV['RUN_AS_SINGLE_PROCESS']
 
-      new(client, reserver, options).work(interval)
+      new(reserver, options).work(interval)
     end
 
     def work(interval = 5.0)
@@ -94,7 +94,7 @@ module Qless
         else
           # We're in the child process
           procline "Processing #{job.description}"
-          @client.redis.client.reconnect
+          job.reconnect_to_redis
           perform(job)
           exit!
         end

--- a/spec/integration/worker_spec.rb
+++ b/spec/integration/worker_spec.rb
@@ -62,7 +62,6 @@ describe "Worker integration", :integration do
     queue = client.queues["main"]
     jid = queue.put(RetryIntegrationJob, {"redis_url" => client.redis.client.id}, retries: 10)
     Qless::Worker.new(
-      client,
       Qless::JobReservers::RoundRobin.new([queue]),
       run_as_a_single_process: true
     ).work(0)
@@ -90,7 +89,7 @@ describe "when the child process is using the redis connection", :integration do
   it 'does not raise an error' do
     queue = client.queues["main"]
     jid = queue.put(NotReconnectingJob, {})
-    Qless::Worker.new(client, Qless::JobReservers::RoundRobin.new([queue]),
+    Qless::Worker.new(Qless::JobReservers::RoundRobin.new([queue]),
       run_as_a_single_process: false
     ).work(0)
 


### PR DESCRIPTION
The Qless::Worker does not need a reference to a client. It restrict
flexibility by coupling it to one client like this.  While it does not
normally make sense to do so, we have a case where would like a
single worker to pull jobs from queues on multiple qless servers,
which works just fine because the queue objects themselves know
what client to talk to.

/cc @proby @dlecocq 
