### PR TITLE
UI: Chrome too paranoid about insecure (http) content

### DIFF
--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -12,7 +12,7 @@
     <link href="<%= u '/css/docs.css' %>" rel="stylesheet">
     <link href="<%= u '/css/jquery.noty.css' %>" rel="stylesheet">
     <link href="<%= u '/css/noty_theme_twitter.css' %>" rel="stylesheet">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 
     <style type="text/css">
     body {


### PR DESCRIPTION
When running the qless web UI securely (https) in Google Chrome, it refuses to load jquery.min.js, which is currently fetched using `http://`. Changing it to `https://` solves the issue. Manually tested to work on Safari and Chrome after patch, with and without SSL.
