### PR TITLE
make qless work with Redis version 2.6.8-pre2

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -205,7 +205,7 @@ module Qless
 	  
 	  # remove the "-pre2" from "2.6.8-pre2"
       *rest, last_el = redis_version.split('.')
-      revised_version = (rest << last_el.split('.')[0]).join('.') if(last_el.index '-')
+      revised_version = (rest << last_el.split('-')[0]).join('.') if(last_el.index '-')
       return if Gem::Version.new(revised_version || redis_version) >= Gem::Version.new(version)
 
       raise UnsupportedRedisVersionError,


### PR DESCRIPTION
At the moment qless fails to start when Redis version is "2.6.8-pre2" because of the "-pre2" in the version number. 

I fixed it by removing the "-pre2" from the version number prior to handing it to Gem::Version.new().

Greetings from 11th on Olympia
Christoph
