### PR TITLE
Make failures use less memory

### DIFF
--- a/lib/qless/worker.rb
+++ b/lib/qless/worker.rb
@@ -205,7 +205,9 @@ module Qless
     end
 
     def format_failure_backtrace(error_backtrace, worker_backtrace)
-      (error_backtrace - worker_backtrace).join("\n")
+      (error_backtrace - worker_backtrace).map do |line|
+        line.sub(Dir.pwd, '.')
+      end.join("\n")
     end
 
     def procline(value)


### PR DESCRIPTION
This removes redundant information from the failure backtraces, greatly cutting down on the amount of memory a backtrace takes.

This cuts out about 70-80% of the backtraces produced by qless's job failure specs.
