### PR TITLE
Fix cancelall method in server to delete all jobs of a failed type

### DIFF
--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -427,7 +427,8 @@ module Qless
       if data["type"].nil?
         halt 400, "Neet type"
       else
-        return json(client.jobs.failed(data["type"])['jobs'].map do |job|
+        count = client.jobs.failed[data["type"]]
+        return json(client.jobs.failed(data["type"], 0, count)['jobs'].map do |job|
           job.cancel()
           { :id => job.jid }
         end)


### PR DESCRIPTION
The number of jobs returned by `client.jobs.failed FAILURE_TYPE` defaults to the first 25 of that type. To delete all jobs of one type at once we need to explicitly specify the number of failed jobs.
