### PR TITLE
Add fix for redis auth support, including spec.

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -218,7 +218,7 @@ module Qless
     end
 
     def new_redis_connection
-      ::Redis.new(url: redis.id)
+      ::Redis.new(@options)
     end
 
   private

--- a/spec/unit/qless_spec.rb
+++ b/spec/unit/qless_spec.rb
@@ -53,6 +53,16 @@ describe Qless do
       client = Qless::Client.new(redis: redis)
       client.redis.should be(redis)
     end
+
+    it 'creates a new redis connection based on initial redis connection options' do
+      options = { host: 'localhost', port: '6379', password: 'awes0me!' }
+      # Create the initial client which also instantiates an initial redis connection
+      client = Qless::Client.new(options)
+
+      # Prepare stub to ensure second connection is instantiated with the same options as initial connection
+      redis_class.stub(:new).with(options)
+      client.new_redis_connection
+    end
   end
 end
 


### PR DESCRIPTION
**Issue**
When AUTH is configured for the redis instance and qless:work is run for a configured queue, the qless worker attempts to subscribe to the redis queue but ends in timeout.

**Analysis**
The reason for this seems to be that the second connection created during the qless worker subscribe is instantiated with a URL generated from the id attribute of the original redis instance.  The problem with this is that the id attribute returns the redis URL without the password, so attempting to connect to the redis instance without a password ends in timeout.

**Fix**
This can be easily rectified by using the original set of options to create the second redis connection which ensures the password is passed through.
