### PR TITLE
Generate the Lua code prior to determining the files in the gemspec.

### DIFF
--- a/qless.gemspec
+++ b/qless.gemspec
@@ -2,6 +2,8 @@
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'qless/version'
 
+`git submodule init && git submodule update && make -C lib/qless/qless-core/`
+
 Gem::Specification.new do |s|
   s.name        = 'qless'
   s.version     = Qless::VERSION


### PR DESCRIPTION
Previously, qless.lua and qless-lib.lua were not getting listed in the generated gemspec because the files didn't exist on disk at the time the glob match occurs for s.files. This ensures that the files exist and therefore get included in the gem.

@myronmarston, @dlecocq I'm not sure how evil you think this might be, but I'm hoping this fixes an issue that prevents qless from being used as a git dependency. It appears that shelling out from a gemspec is at least acceptable. I've seen several examples of it in other repos.

Here's two of the examples that I found in a very casual search:

https://github.com/stereobooster/submodule/blob/master/submodule.gemspec
https://github.com/saltstack/salty-vagrant/blob/develop/vagrant-salt.gemspec
