### PR TITLE
Remove Qless.worker_name.

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -41,17 +41,11 @@ module Qless
     end
   end
 
-  # This is a unique identifier for the worker
-  def worker_name
-    @worker_name ||= [Socket.gethostname, Process.pid.to_s].join('-')
-  end
-
   def failure_formatter
     @failure_formatter ||= FailureFormatter.new
   end
 
-  module_function(
-    :generate_jid, :stringify_hash_keys, :worker_name, :failure_formatter)
+  module_function(:generate_jid, :stringify_hash_keys, :failure_formatter)
 
   # A class for interacting with jobs. Not meant to be instantiated directly,
   # it's accessed through Client#jobs

--- a/lib/qless/worker/base.rb
+++ b/lib/qless/worker/base.rb
@@ -164,7 +164,7 @@ module Qless
 
       def deregister
         uniq_clients.each do |client|
-          client.deregister_workers(Qless.worker_name)
+          client.deregister_workers(client.worker_name)
         end
       end
 
@@ -178,7 +178,7 @@ module Qless
 
       def listen_for_lost_lock
         subscribers = uniq_clients.map do |client|
-          Subscriber.start(client, "ql:w:#{Qless.worker_name}", log_to: output) do |_, message|
+          Subscriber.start(client, "ql:w:#{client.worker_name}", log_to: output) do |_, message|
             if message['event'] == 'lock_lost'
               with_current_job do |job|
                 if job && message['jid'] == job.jid


### PR DESCRIPTION
With the changes in ef2d396055023eba66cc8b9b577abb73ec3ff1db,
it's no longer safe to use when using a forking worker,
because the worker name used by the client could differ
from what `Qless.worker_name` returns, given that it's
lazily initialized, so if it's called for the first
time in a child process, it'll have a different value
then what the client is using, causing problems.

Note: this isn't just a theoretic problem; it was happening
in plines, which referenced Qless.worker_name directly.

/cc @dlecocq 
