### PR TITLE
Empty tagged jobs now returns array

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -65,7 +65,10 @@ module Qless
     end
 
     def tagged(tag, offset = 0, count = 25)
-      JSON.parse(@client.call('tag', 'get', tag, offset, count))
+      results = JSON.parse(@client.call('tag', 'get', tag, offset, count))
+      # Should be an empty array instead of an empty hash
+      results['jobs'] = [] if results['jobs'] == {}
+      results
     end
 
     def failed(t = nil, start = 0, limit = 25)

--- a/spec/integration/qless_spec.rb
+++ b/spec/integration/qless_spec.rb
@@ -69,6 +69,11 @@ module Qless
       expect(client.tags.to_set).to eq(%w{foo bar whiz}.to_set)
     end
 
+    it 'shows empty tagged jobs as an array' do
+      # If there are no jobs with a given tag, it should be an array, not a hash
+      expect(client.jobs.tagged('foo')['jobs']).to eq([])
+    end
+
     it 'exposes bulk cancel' do
       jids = 10.times.map { queue.put('Foo', {}) }
       client.bulk_cancel(jids)


### PR DESCRIPTION
For https://github.com/seomoz/qless/issues/160
