### PR TITLE
update the procline right before the worker starts processing jobs

### DIFF
--- a/lib/qless/worker/serial.rb
+++ b/lib/qless/worker/serial.rb
@@ -20,6 +20,8 @@ module Qless
         reserver.prep_for_work!
 
         listen_for_lost_lock do
+          procline "Running #{reserver.description}"
+
           jobs.each do |job|
             # Run the job we're working on
             log(:info, "Starting job #{job.klass_name} (#{job.jid} from #{job.queue_name})")


### PR DESCRIPTION
This helps in 2 ways:
1. Makes it more clear that the process is running rather than starting
2. When using the `ShuffledRoundRobin` job reserver the procline will show the actual queue ordering that specific worker is using.
