### PR TITLE
Bugfix: Use options for new redis connection

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -223,7 +223,7 @@ module Qless
     end
 
     def new_redis_connection
-      ::Redis.new(url: redis.id)
+      ::Redis.connect(@options)
     end
 
   private


### PR DESCRIPTION
The code created a new redis connection using the `Redis#id` method, but this doesn't include the password. Using the original options given to the Qless::Client copies the password option, without which the qless worker fails.

Some specs appear to fail even on the master branch, so I don't think I broke any specs that weren't already broken.
