### PR TITLE
add pagination to worker counts, preserves backwards compatibility

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -110,8 +110,8 @@ module Qless
       @client = client
     end
 
-    def counts
-      JSON.parse(@client.call('workers'))
+    def counts(offset = 0, count = 0)
+      JSON.parse(@client.call('workers', offset, count))
     end
 
     def [](name)

--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -100,7 +100,7 @@ module Qless
       end
 
       def workers
-        client.workers.counts
+        client.workers.counts(0, PAGE_SIZE)
       end
 
       def failed
@@ -242,7 +242,8 @@ module Qless
 
     get '/workers/?' do
       erb :workers, layout: true, locals: {
-        title: 'Workers'
+        title: 'Workers',
+        workers: paginated(client.workers, :counts)
       }
     end
 

--- a/lib/qless/server/views/workers.erb
+++ b/lib/qless/server/views/workers.erb
@@ -12,3 +12,4 @@
   </div>
 </div>
 <% end %>
+<%= erb :_pagination, :layout => false %>

--- a/spec/integration/qless_spec.rb
+++ b/spec/integration/qless_spec.rb
@@ -46,6 +46,34 @@ module Qless
         })
       end
 
+      it 'paginates access to worker stats' do
+        expect(client.workers.counts).to eq({})
+
+        3.times do |i|
+          client.worker_name = "worker-#{i}"
+          queue.put('Foo', {}, jid: "jid-#{i}")
+          queue.pop
+        end
+
+        worker_names = client.workers.counts().collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-2', 'worker-1', 'worker-0'])
+
+        worker_names = client.workers.counts(0, 0).collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-2', 'worker-1', 'worker-0'])
+
+        worker_names = client.workers.counts(0, 1).collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-2'])
+
+        worker_names = client.workers.counts(1, 1).collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-1'])
+
+        worker_names = client.workers.counts(2, 1).collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-0'])
+
+        worker_names = client.workers.counts(1, 2).collect {|h| h['name'] }
+        expect(worker_names).to eq(['worker-1', 'worker-0'])
+      end
+
       it 'can deregister workers' do
         # Ensure there's a worker listed
         queue.put('Foo', {}, jid: 'jid')


### PR DESCRIPTION
With any significant number of workers (we have 1300, soon to be 8K+), workers.counts becomes unwieldy, especially in the  webui.

I tried to preserve backwards compatibility, so workers.counts without any args returns the entire set like it did before.

I also tried to match existing signatures that have pagination (e.g. offset, count as arguments).

Depends on https://github.com/seomoz/qless-core/pull/42
