### PR TITLE
Fix queue heartbeat return value

### DIFF
--- a/lib/qless/queue.rb
+++ b/lib/qless/queue.rb
@@ -58,7 +58,11 @@ module Qless
     end
 
     def heartbeat
-      get_config :heartbeat
+      if heartbeat_config = get_config(:heartbeat)
+        heartbeat_config.to_i
+      else
+        nil
+      end
     end
 
     def heartbeat=(value)

--- a/spec/integration/queue_spec.rb
+++ b/spec/integration/queue_spec.rb
@@ -16,7 +16,7 @@ module Qless
         expect(queue.jobs.send(cmd)).to eq([])
       end
     end
-    
+
     it 'provides access to job counts' do
       queue.put('Foo', {})
       expect(queue.counts).to eq({
@@ -29,6 +29,11 @@ module Qless
         'stalled'   => 0,
         'waiting'   => 1
       })
+    end
+
+    it "returns a nil heartbeat if the heartbeat hasn't been explicitly configured" do
+      queue = client.queues['an_unconfigured_queue']
+      expect(queue.heartbeat).to be_nil
     end
 
     it 'provides access to the heartbeat configuration' do

--- a/spec/integration/queue_spec.rb
+++ b/spec/integration/queue_spec.rb
@@ -33,8 +33,11 @@ module Qless
 
     it 'provides access to the heartbeat configuration' do
       original = queue.heartbeat
-      queue.heartbeat = 10
-      expect(queue.heartbeat).to_not eq(original)
+      expect {
+        queue.heartbeat = 10
+      }.to change {
+        queue.heartbeat
+      }.from(original).to(10)
     end
 
     it 'provides an array of jobs when using multi-pop' do


### PR DESCRIPTION
Qless handles per-queue heartbeat config like any other config, meaning it's stored in a string->string map. This is confusing for the user, since heartbeat intervals are numeric. This PR modifies the client to return per-queue heartbeat less surprisingly as a numeric.
