### PR TITLE
Subscriber deadlock when redis returns an error.

### DIFF
--- a/lib/qless/worker/base.rb
+++ b/lib/qless/worker/base.rb
@@ -177,6 +177,9 @@ module Qless
       end
 
       def listen_for_lost_lock
+        # Ensure we always have an array
+        # for the ensure block
+        subscribers = []
         subscribers = uniq_clients.map do |client|
           Subscriber.start(client, "ql:w:#{client.worker_name}", log_to: output) do |_, message|
             if message['event'] == 'lock_lost'


### PR DESCRIPTION
Fixes a deadlock in the start method when the thread fails to connect to the channel for various reasons.
