### PR TITLE
Deprecate qless/tasks since they don’t work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,31 +162,41 @@ it is empty, before trying to pop job off the second queue. The
 round-robin reserver will pop a job off the first queue, then the second
 queue, and so on. You could also easily implement your own.
 
-To start a worker, load the qless rake tasks in your Rakefile, and
-define a `qless:setup` task:
+To start a worker, write a bit of Ruby code that instantiates a
+worker and runs it. You could write a rake task to do this, for
+example:
 
 ``` ruby
-require 'qless/tasks'
 namespace :qless do
-  task :setup do
-    require 'my_app/environment' # to ensure all job classes are loaded
+  desc "Run a Qless worker"
+  task :work do
+    # Load your application code. All job classes must be loaded.
+    require 'my_app/environment'
 
-    # Set options via environment variables
-    # The only required option is QUEUES; the
-    # rest have reasonable defaults.
-    ENV['REDIS_URL'] ||= 'redis://some-host:7000/3'
-    ENV['QUEUES'] ||= 'fizz,buzz'
-    ENV['JOB_RESERVER'] ||= 'Ordered'
-    ENV['INTERVAL'] ||= '10' # 10 seconds
-    ENV['VERBOSE'] ||= 'true'
+    # Require the parts of qless you need
+    require 'qless'
+    require 'qless/job_reservers/ordered'
+    require 'qless/worker'
+
+    # Create a client
+    client = Qless::Client.new(:host => 'foo.bar.com', :port => 1234)
+
+    # Get the queues you use
+    queues = %w[ queue_1 queue_2 ].map do |name|
+      client.queues[name]
+    end
+
+    # Create a job reserver; different reservers use different
+    # strategies for which order jobs are popped off of queues
+    reserver = Qless::JobReservers::Ordered.new(queues)
+
+    # Create a forking worker that uses the given reserver to pop jobs.
+    worker = Qless::Workers::ForkingWorker.new(reserver)
+
+    # Start the worker!
+    worker.run
   end
 end
-```
-
-Then run the `qless:work` rake task:
-
-```
-rake qless:work
 ```
 
 The following signals are supported in the parent process:

--- a/lib/qless/tasks.rb
+++ b/lib/qless/tasks.rb
@@ -1,11 +1,5 @@
 # Encoding: utf-8
-
-namespace :qless do
-  task :setup # no-op; users should define their own setup
-
-  desc 'Start a worker with env: QUEUES, JOB_RESERVER, REDIS_URL, INTERVAL'
-  task work: :setup do
-    require 'qless/worker'
-    Qless::Worker.start
-  end
-end
+warn "Qless tasks are deprecated (they haven't worked for " \
+     "quite some time) and you should start a worker by " \
+     "writing a bit of ruby code that instantiates and " \
+     "runs a worker instead."


### PR DESCRIPTION
Create new `run_test_worker` task.

Fixes #197.