### PR TITLE
Pause worker before it reserves a job

### DIFF
--- a/lib/qless/worker/serial.rb
+++ b/lib/qless/worker/serial.rb
@@ -27,12 +27,6 @@ module Qless
             log(:debug, "Starting job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
             perform(job)
             log(:debug, "Finished job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
-
-            # So long as we're paused, we should wait
-            while paused
-              log(:debug, 'Paused...')
-              sleep interval
-            end
           end
         end
       end


### PR DESCRIPTION
Fixes #234 

Moved to code that checks for a paused worker before worker reserves a job so it can pause without having to perform a job.
