### PR TITLE
add check for in_signal_handler condition

### DIFF
--- a/lib/qless/worker/base.rb
+++ b/lib/qless/worker/base.rb
@@ -42,7 +42,7 @@ module Qless
         @current_job = nil
 
         # Default behavior when a lock is lost: stop after the current job.
-        on_current_job_lock_lost { shutdown }
+        on_current_job_lock_lost { shutdown(in_signal_handler=false) }
       end
 
       def log_level
@@ -71,10 +71,10 @@ module Qless
         trap('TERM') { exit! }
         trap('INT')  { exit! }
         safe_trap('HUP') { sighup_handler.call }
-        safe_trap('QUIT') { shutdown }
+        safe_trap('QUIT') { shutdown(in_signal_handler=true) }
         begin
-          trap('CONT') { unpause }
-          trap('USR2') { pause }
+          trap('CONT') { unpause(in_signal_handler=true) }
+          trap('USR2') { pause(in_signal_handler=true) }
         rescue ArgumentError
           warn 'Signals USR2, and/or CONT not supported.'
         end
@@ -134,26 +134,26 @@ module Qless
       include SupportsMiddlewareModules
 
       # Stop processing after this job
-      def shutdown
+      def shutdown(in_signal_handler=true)
         @shutdown = true
       end
       alias stop! shutdown # so we can call `stop!` regardless of the worker type
 
       # Pause the worker -- take no more new jobs
-      def pause
+      def pause(in_signal_handler=true)
         @paused = true
-        procline "Paused -- #{reserver.description}"
+        procline("Paused -- #{reserver.description}", in_signal_handler=in_signal_handler)
       end
 
       # Continue taking new jobs
-      def unpause
+      def unpause(in_signal_handler=true)
         @paused = false
       end
 
       # Set the proceline. Not supported on all systems
-      def procline(value)
+      def procline(value, in_signal_handler=true)
         $0 = "Qless-#{Qless::VERSION}: #{value} at #{Time.now.iso8601}"
-        log(:debug, $PROGRAM_NAME)
+        log(:debug, $PROGRAM_NAME) unless in_signal_handler
       end
 
       # Complete the job unless the worker has already put it into another state
@@ -221,7 +221,7 @@ module Qless
 
       def no_job_available
         unless interval.zero?
-          procline "Waiting for #{reserver.description}"
+          procline("Waiting for #{reserver.description}", in_signal_handler=false)
           log(:debug, "Sleeping for #{interval} seconds")
           sleep interval
         end

--- a/lib/qless/worker/forking.rb
+++ b/lib/qless/worker/forking.rb
@@ -85,14 +85,22 @@ module Qless
         # If we're the parent process, we mostly want to forward the signals on
         # to the child processes. It's just that sometimes we want to wait for
         # them and then exit
-        trap('TERM') { contention_aware_handler { stop!('TERM'); exit } }
-        trap('INT') { contention_aware_handler { stop!('INT'); exit } }
+        trap('TERM') do
+          contention_aware_handler { stop!('TERM', in_signal_handler=true); exit }
+        end
+        trap('INT') do
+          contention_aware_handler { stop!('INT', in_signal_handler=true); exit }
+        end
         safe_trap('HUP') { sighup_handler.call }
-        safe_trap('QUIT') { contention_aware_handler { stop!('QUIT'); exit } }
-        safe_trap('USR1') { contention_aware_handler { stop!('KILL') } }
+        safe_trap('QUIT') do
+          contention_aware_handler { stop!('QUIT', in_signal_handler=true); exit }
+        end
+        safe_trap('USR1') do
+          contention_aware_handler { stop!('KILL', in_signal_handler=true) }
+        end
         begin
-          trap('CONT') { stop('CONT') }
-          trap('USR2') { stop('USR2') }
+          trap('CONT') { stop('CONT', in_signal_handler=true) }
+          trap('USR2') { stop('USR2', in_signal_handler=true) }
         rescue ArgumentError
           warn 'Signals USR2, and/or CONT not supported.'
         end
@@ -133,8 +141,8 @@ module Qless
       end
 
       # Signal all the children
-      def stop(signal = 'QUIT')
-        log(:warn, "Sending #{signal} to children")
+      def stop(signal = 'QUIT', in_signal_handler=true)
+        log(:warn, "Sending #{signal} to children") unless in_signal_handler
         children.each do |pid|
           begin
             Process.kill(signal, pid)
@@ -146,9 +154,9 @@ module Qless
 
       # Signal all the children and wait for them to exit.
       # Should only be called when we have the lock on @sandbox_mutex
-      def stop!(signal = 'QUIT')
-        shutdown
-        shutdown_sandboxes(signal)
+      def stop!(signal = 'QUIT', in_signal_handler=true)
+        shutdown(in_signal_handler=in_signal_handler)
+        shutdown_sandboxes(signal, in_signal_handler=in_signal_handler)
       end
 
     private
@@ -176,28 +184,31 @@ module Qless
       end
 
       # Should only be called when we have a lock on @sandbox_mutex
-      def shutdown_sandboxes(signal)
+      def shutdown_sandboxes(signal, in_signal_handler=true)
         # First, send the signal
-        stop(signal)
+        stop(signal, in_signal_handler=in_signal_handler)
 
         # Wait for each of our children
-        log(:warn, 'Waiting for child processes')
+        log(:warn, 'Waiting for child processes') unless in_signal_handler
 
         until @sandboxes.empty?
           begin
             pid, _ = Process.wait2
-            log(:warn, "Child #{pid} stopped")
+            log(:warn, "Child #{pid} stopped") unless in_signal_handler
             @sandboxes.delete(pid)
           rescue SystemCallError
             break
           end
         end
 
-        log(:warn, 'All children have stopped')
 
-        # If there were any children processes we couldn't wait for, log it
-        @sandboxes.keys.each do |cpid|
-          log(:warn, "Could not wait for child #{cpid}")
+        unless in_signal_handler
+          log(:warn, 'All children have stopped')
+
+          # If there were any children processes we couldn't wait for, log it
+          @sandboxes.keys.each do |cpid|
+            log(:warn, "Could not wait for child #{cpid}")
+          end
         end
 
         @sandboxes.clear


### PR DESCRIPTION
Some design considerations:
* there is no clean way to check whether we are in signal handling context, so it needs to be passed as parameter.
* the right way (and, hopefully, one day available) is to pass it as a keyword parameter. Except that we are still supporting 1.9.x Ruby
* when switching to keyword would occur, the defaults would disappear from method definitions (and ugly `in_signal_handler=in_signal_handler` as well. It is also a bit safer since some existing methods use parameters with default.