### PR TITLE
Hack to add "unfail all jobs" to UI under failed tab

### DIFF
--- a/lib/qless.rb
+++ b/lib/qless.rb
@@ -210,6 +210,21 @@ module Qless
       call('track', 'untrack', jid)
     end
 
+    def unfail(destqueue, group, batch_size=100)
+      call('unfail', destqueue, group, batch_size)
+    end
+
+    def unfail_all!(batch_size=10000, debug=false)
+      jobs.failed.each do |group, kount|
+        destqueue = jobs.failed(group, 0, 1)['jobs'][0].queue.name
+        kount = (kount.to_f / batch_size).ceil.to_i
+        if debug
+          puts "#{kount}.times { call('unfail', #{destqueue.inspect}, #{group.inspect}, #{batch_size.inspect}) }"
+        end
+        kount.times { unfail(destqueue, group, batch_size) }
+      end
+    end
+
     def tags(offset = 0, count = 100)
       JSON.parse(call('tag', 'top', offset, count))
     end

--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -194,6 +194,11 @@ module Qless
       }
     end
 
+    post '/unfail_all' do
+      client.unfail_all!
+      redirect to(request.referrer)
+    end
+
     get '/failed.json' do
       json(client.jobs.failed)
     end

--- a/lib/qless/server/views/failed.erb
+++ b/lib/qless/server/views/failed.erb
@@ -16,6 +16,9 @@
   <div class="page-header">
     <h1>Failed Jobs <small>Failure is a Part of Success!</small></h1>
   </div>
+  <form action="<%= u "/unfail_all" %>" method="post">
+    <input type="submit" value="Unfail all jobs!" />
+  </form>
 <% end %>
 
 <div class="tab-content">


### PR DESCRIPTION
I've been using this successfully in an internal project here (workparty) for a while. I'm going to need this for another project.
