### PR TITLE
Correctly declare thin dependency in gemspec file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,4 @@ services:
   - redis-server
 script: bundle exec rake
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.1.1
-  - 2.1.5
+  - 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ group :extras do
   gem 'debugger', :platform => :mri_19
 end
 
-gem 'thin' # needed by qless-web binary
-
 group :development do
   gem 'byebug', :platforms => [:ruby_20, :ruby_21]
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qless (0.10.0.pre2)
+    qless (0.10.0)
       redis (>= 2.2)
 
 GEM
@@ -88,7 +88,7 @@ GEM
       rack (>= 1.0)
     rainbow (1.1.4)
     rake (10.1.0)
-    redis (3.2.1)
+    redis (3.2.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -165,4 +165,4 @@ DEPENDENCIES
   vegas (~> 0.1.11)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
     columnize (0.3.6)
-    daemons (1.1.9)
+    daemons (1.2.3)
     debug_inspector (0.0.2)
     debugger (1.6.2)
       columnize (>= 0.3.1)
@@ -38,7 +38,7 @@ GEM
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.2.3)
     diff-lcs (1.2.4)
-    eventmachine (1.0.3)
+    eventmachine (1.0.9.1)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     faye-websocket (0.4.7)
@@ -81,7 +81,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    rack (1.5.2)
+    rack (1.6.4)
     rack-protection (1.5.0)
       rack
     rack-test (0.6.2)
@@ -123,10 +123,10 @@ GEM
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     slop (3.4.6)
-    thin (1.5.1)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
     tilt (1.4.1)
     timecop (0.7.1)
     uuidtools (2.1.4)
@@ -160,9 +160,9 @@ DEPENDENCIES
   sentry-raven (~> 0.4)
   simplecov (~> 0.7.1)
   sinatra (~> 1.3.2)
-  thin
+  thin (~> 1.6.4)
   timecop (~> 0.7.1)
   vegas (~> 0.1.11)
 
 BUNDLED WITH
-   1.10.1
+   1.10.6

--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.10.0.pre2'
+  VERSION = '0.10.0'
 end

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -52,4 +52,5 @@ language-specific extension will also remain up to date.
   s.add_development_dependency 'rubocop'       , '~> 0.13.1'
   s.add_development_dependency 'rusage'        , '~> 0.2.0'
   s.add_development_dependency 'timecop'       , '~> 0.7.1'
+  s.add_development_dependency 'thin'          , '~> 1.6.4'
 end


### PR DESCRIPTION
thin is a required dependency for qless-web. It should be declared as a dependency in the .gemspec (which will then be included in the Gemfile) so that the dependency is picked up even when not installed with bundler.

@dlecocq 

@a1ph4g33k @myronmarston: can you confirm this is good Ruby practice?