### PR TITLE
`qless-config` binary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qless (0.10.0)
+    qless (0.10.1)
       metriks (~> 0.9)
       redis (>= 2.2)
       rusage (~> 0.2.0)
@@ -12,10 +12,10 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.5)
     ast (1.1.0)
     atomic (1.1.99)
-    avl_tree (1.1.3)
+    avl_tree (1.2.1)
+      atomic (~> 1.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     byebug (2.7.0)
@@ -44,25 +44,22 @@ GEM
     debugger-ruby_core_source (1.2.3)
     diff-lcs (1.2.4)
     eventmachine (1.0.9.1)
-    faraday (0.8.8)
-      multipart-post (~> 1.2.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     ffi (1.9.0)
-    hashie (2.0.5)
     hitimes (1.2.3)
     http_parser.rb (0.5.3)
-    launchy (2.1.2)
-      addressable (~> 2.3)
     method_source (0.8.2)
-    metriks (0.9.9.5)
+    metriks (0.9.9.7)
       atomic (~> 1.0)
-      avl_tree (~> 1.1.2)
+      avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
     mime-types (1.25)
     mini_portile (0.5.1)
     multi_json (1.8.0)
-    multipart-post (1.2.0)
+    multipart-post (2.0.0)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     parallel (1.4.1)
@@ -87,7 +84,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     rack (1.6.4)
-    rack-protection (1.5.0)
+    rack-protection (1.5.3)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -115,10 +112,8 @@ GEM
       multi_json (~> 1.0)
       rubyzip (< 1.0.0)
       websocket (~> 1.0.4)
-    sentry-raven (0.6.0)
+    sentry-raven (0.15.6)
       faraday (>= 0.7.6)
-      hashie (>= 1.1.0)
-      uuidtools
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -134,7 +129,6 @@ GEM
       rack (~> 1.0)
     tilt (1.4.1)
     timecop (0.7.1)
-    uuidtools (2.1.4)
     vegas (0.1.11)
       rack (>= 1.0.0)
     websocket (1.0.7)
@@ -147,11 +141,8 @@ PLATFORMS
 DEPENDENCIES
   byebug
   cane
-  capybara (~> 1.1.2)
   debugger
-  faye-websocket (~> 0.4.0)
-  launchy (~> 2.1.0)
-  poltergeist
+  poltergeist (~> 1.0.0)
   pry
   pry-byebug
   pry-stack_explorer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       rusage (~> 0.2.0)
       sentry-raven (~> 0.4)
       sinatra (~> 1.3.2)
+      thor (~> 0.19.1)
       vegas (~> 0.1.11)
 
 GEM
@@ -127,6 +128,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
+    thor (0.19.1)
     tilt (1.4.1)
     timecop (0.7.1)
     vegas (0.1.11)

--- a/exe/qless-config
+++ b/exe/qless-config
@@ -1,0 +1,45 @@
+#! /usr/bin/env ruby
+
+require 'json'
+require 'qless'
+require 'thor'
+
+class Configurator < Thor
+
+  class_option :redis, :default => 'redis://localhost:6379/0'
+
+  no_commands do
+    def qless
+      if @qless.nil?
+        @qless = Qless::Client.new(url: options[:redis])
+      end
+      @qless
+    end
+  end
+
+  desc 'dump', 'Get config and print to stdout'
+  def dump
+    puts JSON.pretty_generate(qless.config.all)
+  end
+
+  desc 'load <filename> [--clear]', 'Set config from a file and command-line args'
+  option :clear, :type => :boolean, :default => false
+  def load(filename)
+    File.open(filename) do |file|
+      values = JSON.load(file)
+
+      if options[:clear]
+        (qless.config.all.keys - values.keys).each do |key|
+          qless.config.clear(key)
+        end
+      end
+
+      values.each do |key, value|
+        qless.config[key] = value
+      end
+    end
+  end
+
+end
+
+Configurator.start(ARGV)

--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -41,4 +41,5 @@ language-specific extension will also remain up to date.
   s.add_dependency 'sinatra', '~> 1.3.2'
   s.add_dependency 'vegas', '~> 0.1.11'
   s.add_dependency 'rusage', '~> 0.2.0'
+  s.add_dependency 'thor', '~> 0.19.1'
 end

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -30,7 +30,7 @@ language-specific extension will also remain up to date.
   s.files        += Dir.glob('exe/**/*')
   s.files        += Dir.glob('lib/qless/server/**/*')
   s.bindir        = 'exe'
-  s.executables   = ['qless-web']
+  s.executables   = ['qless-web', 'qless-config']
 
   s.test_files    = s.files.grep(/^(test|spec|features)\//)
   s.require_paths = ['lib']

--- a/spec/integration/exe/qless_config_spec.rb
+++ b/spec/integration/exe/qless_config_spec.rb
@@ -1,0 +1,53 @@
+# Encoding: utf-8
+
+require 'json'
+require 'tempfile'
+
+require 'spec_helper'
+
+describe 'qless-config', :integration do
+  let(:path) { './exe/qless-config' }
+
+  let(:default) do
+    {
+      'application' => 'qless',
+      'grace-period' => 10,
+      'stats-history' => 30,
+      'jobs-history' => 604800,
+      'heartbeat' => 60,
+      'jobs-history-count' => 50000,
+      'histogram-history' => 7
+    }
+  end
+
+  def options_fixture(options = {})
+    Tempfile.open('fixture') do |f|
+      JSON.dump(options, f)
+      f.flush
+      yield f.path
+    end
+  end
+
+  def run(*args)
+    `#{path} #{args.join(' ')}`
+  end
+
+  it 'runs dump' do
+    expect(JSON.parse(run('dump'))).to eq(default)
+  end
+
+  it 'runs load' do
+    options_fixture(:foo => 'bar') do |path|
+      run('load', path)
+    end
+    expect(client.config['foo']).to eq('bar')
+  end
+
+  it 'can clear variables' do
+    client.config['foo'] = 'bar'
+    options_fixture do |path|
+      run('load', path, '--clear')
+    end
+    expect(client.config.all).to eq(default)
+  end
+end


### PR DESCRIPTION
When setting up a new qless instance, a common part of that is to set some configuration for the application name, heartbeat intervals, maximum concurrency, etc. To this end, we've written little snippets here and there depending on what fits with the project. From `shovel` tasks to `Java`-based command-line utilities (sadly, it's true).

Rather than write this utility in multiple languages, it makes sense to have it adjacent to the `qless-web` binary. Since most installations at least include the UI, that would mean that each installation would also then have access to this helper.

It provides two subcommands:1)  `dump`, which prints out the current configuration as JSON and 2) `load` which accepts a path to a JSON file and sets the configuration accordingly. The `load` subcommand also accepts `--clear` which unsets any configuration present on the server that is absent from the provided config.