### PR TITLE
Relax sinatra version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qless (0.10.1)
+    qless (0.10.2)
       metriks (~> 0.9)
       redis (>= 2.2)
       rusage (~> 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       redis (>= 2.2)
       rusage (~> 0.2.0)
       sentry-raven (~> 0.4)
-      sinatra (~> 1.3.2)
+      sinatra (~> 1.3)
       thin (~> 1.6.4)
       thor (~> 0.19.1)
       vegas (~> 0.1.11)

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -39,7 +39,7 @@ language-specific extension will also remain up to date.
   s.add_dependency 'redis', '>= 2.2'
   s.add_dependency 'rusage', '~> 0.2.0'
   s.add_dependency 'sentry-raven', '~> 0.4'
-  s.add_dependency 'sinatra', '~> 1.3.2'
+  s.add_dependency 'sinatra', '~> 1.3'
   s.add_dependency 'thin', '~> 1.6.4'
   s.add_dependency 'thor', '~> 0.19.1'
   s.add_dependency 'vegas', '~> 0.1.11'


### PR DESCRIPTION
Sinatra 1.3.6 was released on March 15, 2013. The current version is 1.4.7. Relaxing the version constraint to allow users to use versions 1.4.0 and above without breaking existing users who want to stay on 1.3.6.