### PR TITLE
Fix event notification example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ to make use of this is in the `qless-campfire` or `qless-growl`. The jist of it 
 this, though:
 
 ``` ruby
-client.events do |on|
+client.events.listen do |on|
   on.canceled  { |jid| puts "#{jid} canceled"   }
   on.stalled   { |jid| puts "#{jid} stalled"    }
   on.track     { |jid| puts "tracking #{jid}"   }


### PR DESCRIPTION
Hello! I noticed while working with Qless on a project that the code I had referenced in the README...wasn't actually getting any events. After digging into the example code I discovered that the README code sample was wrong (you need to call `.listen`); this PR updates the README code sample.

@dlecocq @proby 