### PR TITLE
when waiting on childs, check that they were spawned by us before acting

### DIFF
--- a/lib/qless/worker/forking.rb
+++ b/lib/qless/worker/forking.rb
@@ -118,6 +118,9 @@ module Qless
 
             # Wait for any child to kick the bucket
             pid, status = Process.wait2
+            # only care about processes we spawned
+            next unless @sandboxes[pid]
+
             code, sig = status.exitstatus, status.stopsig
             log((code == 0 ? :info : :warn),
               "Worker process #{pid} died with #{code} from signal (#{sig})")


### PR DESCRIPTION
This caused a curious case of forking a new worker any time something unrelated to the worker code (but originating in the same parent process) forked and exited. 

There's still race conditions in the code (such as trying to maintain a worker pool and missing some process exits while checking on others) which should probably fixed in another diff.