### PR TITLE
Pin redis to less than 4.0.0.rc1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     qless (0.10.4)
       metriks (~> 0.9)
-      redis (>= 2.2, < 4)
+      redis (>= 2.2, < 4.0.0.rc1)
       rusage (~> 0.2.0)
       sentry-raven (~> 0.4)
       sinatra (~> 1.3)
@@ -161,4 +161,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.10.4'
+  VERSION = '0.10.5'
 end

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -36,7 +36,7 @@ language-specific extension will also remain up to date.
   s.require_paths = ['lib']
 
   s.add_dependency 'metriks', '~> 0.9'
-  s.add_dependency 'redis', ['>= 2.2', '< 4']
+  s.add_dependency 'redis', ['>= 2.2', '< 4.0.0.rc1']
   s.add_dependency 'rusage', '~> 0.2.0'
   s.add_dependency 'sentry-raven', '~> 0.4'
   s.add_dependency 'sinatra', '~> 1.3'


### PR DESCRIPTION
It turns out that `4.0.0.rc1` is less than `4`, so the previous pinning was insufficient. I have verified that this does what I'm after.

@myronmarston @b4hand 