### PR TITLE
Loosen the restrictions on sinatra and thin versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    qless (0.10.4)
+    qless (0.10.5)
       metriks (~> 0.9)
       redis (>= 2.2, < 4.0.0.rc1)
       rusage (~> 0.2.0)
       sentry-raven (~> 0.4)
-      sinatra (~> 1.3)
+      sinatra (>= 1.3, < 2.1)
       statsd-ruby (~> 1.3)
-      thin (~> 1.6.4)
+      thin (~> 1.6)
       thor (~> 0.19.1)
       vegas (~> 0.1.11)
 
@@ -47,15 +47,15 @@ GEM
     debugger-ruby_core_source (1.2.3)
     diff-lcs (1.2.4)
     eventmachine (1.0.9.1)
-    faraday (0.10.0)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     ffi (1.9.0)
-    hitimes (1.2.4)
+    hitimes (1.2.6)
     http_parser.rb (0.5.3)
     method_source (0.8.2)
-    metriks (0.9.9.7)
+    metriks (0.9.9.8)
       atomic (~> 1.0)
       avl_tree (~> 1.2.0)
       hitimes (~> 1.1)
@@ -93,7 +93,7 @@ GEM
       rack (>= 1.0)
     rainbow (1.1.4)
     rake (10.1.0)
-    redis (3.2.2)
+    redis (3.3.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -121,18 +121,18 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.4.6)
-    statsd-ruby (1.3.0)
+    statsd-ruby (1.4.0)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     thor (0.19.4)
-    tilt (2.0.5)
+    tilt (2.0.8)
     timecop (0.7.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -161,4 +161,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.13.6
+   1.15.3

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -39,9 +39,9 @@ language-specific extension will also remain up to date.
   s.add_dependency 'redis', ['>= 2.2', '< 4.0.0.rc1']
   s.add_dependency 'rusage', '~> 0.2.0'
   s.add_dependency 'sentry-raven', '~> 0.4'
-  s.add_dependency 'sinatra', '~> 1.3'
+  s.add_dependency 'sinatra', ['>= 1.3', '< 2.1']
   s.add_dependency 'statsd-ruby', '~> 1.3'
-  s.add_dependency 'thin', '~> 1.6.4'
+  s.add_dependency 'thin', '~> 1.6'
   s.add_dependency 'thor', '~> 0.19.1'
   s.add_dependency 'vegas', '~> 0.1.11'
 


### PR DESCRIPTION
Rails 5 depends on Rack 2.0+. Loosing the restrictions on `sinatra` and `thin` gems will allow `qless` to run on both, `rack ~> 1.0` as well as `rack ~> 2.0`.
At @Shopify we have successfully run `qless` on top of `sinatra 2` and `thin 1.7` within Rails 5 apps for quite some time now.
Hopefully this change will help other people who are struggling with running `qless` with the latest versions of `rails`.