### PR TITLE
Use `--porcelain` in core:verify:clean task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,8 +51,8 @@ namespace :core do
     desc "Verifies the script has no uncommitted changes"
     task :clean do
       script_files.each do |file|
-        git_status = `git status -- #{file}`
-        unless /working directory clean/.match(git_status)
+        git_status = `git status --porcelain -- #{file}`
+        unless git_status.strip.empty?
           raise "#{file} is dirty: \n\n#{git_status}\n\n"
         end
       end


### PR DESCRIPTION
The output of this command is guaranteed to not change. It appears that Travis is failing because the prior match was not succeeding.

I confirmed locally that the task was succeeding for me both before and after this change, and then I also manually modified the files in question and confirmed it fails if they are modified.

This is to fix the Travis failure in #266.