### PR TITLE
Force precise for Travis builds for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+sudo: false
+dist: precise
 bundler_args: --without extras
 before_script:
-  # From: https://github.com/jonleighton/poltergeist/blob/v1.0.0/.travis.yml#L5-7
-  - git submodule init
-  - git submodule update
   - bundle exec rake core:verify
 branches:
   only:


### PR DESCRIPTION
This is a temporary fix to workaround the fact that Travis has upgraded the default installed version of `redis-server` to a version newer than qless supports. By reverting to precise, we should get a redis 2 instance.