### PR TITLE
Release version 0.11.0.

### DIFF
--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.10.5'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
There's been no new release to rubygems.org in a little over a year now. Plus, there's been several changes to master that bumped required Gem versions including a bunch of security patches, so I think a minor version bump is desirable.