### PR TITLE
Rename "failures" to "failed" in qless-stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,3 +663,12 @@ Mailing List
 
 For questions and general Qless discussion, please join the [Qless
 Mailing list](https://groups.google.com/forum/?fromgroups#!forum/qless).
+
+Release Notes
+=============
+
+0.12.0
+------
+The metric `failures` provided by `qless-stats` has been replaced by `failed` for
+compatibility with users of `graphite`. See [#275](https://github.com/seomoz/qless/pull/275)
+for more details.

--- a/exe/qless-stats
+++ b/exe/qless-stats
@@ -96,7 +96,7 @@ class Stats < Thor
         client.gauge "failures.#{failure}", count
         count
       end.reduce(0, :+)
-      client.gauge 'failures', total
+      client.gauge 'failed', total
 
       # Track workers
       client.gauge 'workers', qless.workers.counts.length

--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/integration/exe/qless_stats_spec.rb
+++ b/spec/integration/exe/qless_stats_spec.rb
@@ -124,7 +124,7 @@ describe 'qless-stats', :integration do
       end
 
       it 'tracks total failures' do
-        expect(messages).to include('failures:1|g')
+        expect(messages).to include('failed:1|g')
       end
 
       it 'tracks worker counts' do


### PR DESCRIPTION
Graphite/whisper cannot have a name that serves both as a metric name and as a dot-delimited prefix to another metric. Because individual failure types are reported as "failures.<type>", the "failures" metric fails to be reported if ever there has been a report of "failures.<type>". While this tool is not specific to graphite, it is a common tool in the monitoring ecosystem and it takes little effort to make this tool compatible.

@b4hand @evanbattaglia @kq2