### PR TITLE
Show currently running job in qless worker procline

### DIFF
--- a/lib/qless/worker/serial.rb
+++ b/lib/qless/worker/serial.rb
@@ -25,6 +25,7 @@ module Qless
           jobs.each do |job|
             # Run the job we're working on
             log(:debug, "Starting job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
+            procline "Processing: #{job.jid} (#{job.klass_name}) from #{job.queue_name}"
             perform(job)
             log(:debug, "Finished job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
 


### PR DESCRIPTION
It looks like this may have been inadvertently removed in dc0684d2. This
PR restores that behavior, albeit in a slightly different format.
Notably we omit the job state (since it must be running), and the job
data, which could be reasonably large.