### PR TITLE
fix a compatability issue with Valkey 8 forward

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    qless (0.14.0)
+    qless (0.15.0)
       redis (>= 2.2, < 5)
       rusage (~> 0.2.0)
       sentry-raven (22.7.0)

--- a/README.md
+++ b/README.md
@@ -672,3 +672,12 @@ Release Notes
 The metric `failures` provided by `qless-stats` has been replaced by `failed` for
 compatibility with users of `graphite`. See [#275](https://github.com/seomoz/qless/pull/275)
 for more details.
+
+0.14.0
+------
+Make Qless compatible with Redis 6.0+. See [#299](https://github.com/seomoz/qless/pull/299)
+
+0.15.0
+------
+Make Qless compatible with breaking change introduced in Valkey 8+.
+[#300](https://github.com/seomoz/qless/pull/300)

--- a/lib/qless/lua_script.rb
+++ b/lib/qless/lua_script.rb
@@ -55,9 +55,10 @@ module Qless
     # Module for notifying when a script hasn't yet been loaded
     module ScriptNotLoadedRedisCommandError
       MESSAGE = 'NOSCRIPT No matching script. Please use EVAL.'
+      VALKEY_MESSAGE = 'NOSCRIPT No matching script.'
 
       def self.===(error)
-        error.is_a?(Redis::CommandError) && error.message == MESSAGE
+        error.is_a?(Redis::CommandError) && (error.message == MESSAGE || error.message == VALKEY_MESSAGE)
       end
     end
 

--- a/lib/qless/version.rb
+++ b/lib/qless/version.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
 
 module Qless
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
Valkey 8 introduced a change to an error message that created an incompatibility when trying to catch the error that we need to reload the Lua scripts for. Valkey opted not to revert these changes even though it created issues with external dependencies like Qless.

This change simply adds another match text for the error message to regain compatibility.

**Issue link from Valkey**: https://github.com/valkey-io/valkey/issues/1537

**Code change in Valkey**: https://github.com/valkey-io/valkey/pull/617/changes#diff-1abc5651133d108c0c420d9411925373c711133e7748d9e4f4c97d5fb543fdd9R1819