### PR TITLE
Use prefix matching for NOSCRIPT errors

### DIFF
--- a/lib/qless/lua_script.rb
+++ b/lib/qless/lua_script.rb
@@ -54,11 +54,8 @@ module Qless
 
     # Module for notifying when a script hasn't yet been loaded
     module ScriptNotLoadedRedisCommandError
-      MESSAGE = 'NOSCRIPT No matching script. Please use EVAL.'
-      VALKEY_MESSAGE = 'NOSCRIPT No matching script.'
-
       def self.===(error)
-        error.is_a?(Redis::CommandError) && (error.message == MESSAGE || error.message == VALKEY_MESSAGE)
+        error.is_a?(Redis::CommandError) && error.message.start_with?('NOSCRIPT')
       end
     end
 


### PR DESCRIPTION
## Changes
- Simplified `ScriptNotLoadedRedisCommandError.=== to use start_with?('NOSCRIPT')` instead of exact string matching against hardcoded constants
- Removed the `MESSAGE` and `VALKEY_MESSAGE` constants — no more updating them every time a Redis-compatible server uses a slightly different NOSCRIPT error message
- Ensures forward compatibility with Redis, Valkey, and any other compatible server
## Background
Previously, we matched against two specific error strings:
```
MESSAGE = 'NOSCRIPT No matching script. Please use EVAL.'
VALKEY_MESSAGE = 'NOSCRIPT No matching script.'
```
Since all NOSCRIPT errors follow the Redis protocol and start with NOSCRIPT, prefix matching is simpler and more robust — no need to add a new constant for each server variant.

## Testing
Tested in [Speke](https://github.com/seomoz/speke) on branch `ladan/migrate-redis-to-valkey` against Valkey 8.0. Full test suite passes (543 examples, 0 failures). NOSCRIPT errors are correctly caught and Lua scripts reload as expected.